### PR TITLE
Add unit tests for service implementations

### DIFF
--- a/src/test/java/io/github/vulpes/applications/service/PagamentoServiceTest.java
+++ b/src/test/java/io/github/vulpes/applications/service/PagamentoServiceTest.java
@@ -1,0 +1,133 @@
+package io.github.vulpes.applications.service;
+
+import io.github.vulpes.applications.dto.PagamentoDTO;
+import io.github.vulpes.applications.service.impl.PagamentoServiceImpl;
+import io.github.vulpes.domain.models.Assinante;
+import io.github.vulpes.domain.models.Pagamento;
+import io.github.vulpes.domain.models.StatusPagamentoMensal;
+import io.github.vulpes.infrastructure.jpa.AssinanteRepository;
+import io.github.vulpes.infrastructure.jpa.PagamentoRepository;
+import io.github.vulpes.infrastructure.jpa.StatusPagamentoMensalRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class PagamentoServiceTest {
+
+    @Mock
+    private PagamentoRepository pagamentoRepository;
+    @Mock
+    private StatusPagamentoMensalRepository statusPagamentoMensalRepository;
+    @Mock
+    private AssinanteRepository assinanteRepository;
+
+    @InjectMocks
+    private PagamentoServiceImpl pagamentoService;
+
+    private final ModelMapper modelMapper = new ModelMapper();
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        pagamentoService = new PagamentoServiceImpl(pagamentoRepository, statusPagamentoMensalRepository, assinanteRepository);
+    }
+
+    @Test
+    void testRegistrarPagamento() {
+        PagamentoDTO dto = new PagamentoDTO();
+        dto.setAssinanteId(1L);
+        dto.setValorPago(BigDecimal.TEN);
+        dto.setMesesCobertos(2);
+        dto.setDataPagamento(LocalDateTime.now());
+
+        Assinante assinante = new Assinante();
+        assinante.setId(1L);
+        when(assinanteRepository.findById(1L)).thenReturn(Optional.of(assinante));
+        when(pagamentoRepository.save(any(Pagamento.class))).thenAnswer(invocation -> {
+            Pagamento p = invocation.getArgument(0);
+            p.setId(1L);
+            return p;
+        });
+
+        PagamentoDTO result = pagamentoService.registrarPagamento(dto);
+
+        verify(pagamentoRepository).save(any(Pagamento.class));
+        verify(statusPagamentoMensalRepository, times(2)).save(any(StatusPagamentoMensal.class));
+        assertEquals(1L, result.getId());
+        assertEquals(dto.getValorPago(), result.getValorPago());
+    }
+
+    @Test
+    void testAtualizarPagamento() {
+        Pagamento pagamento = Pagamento.builder().id(1L).assinante(new Assinante()).valorPago(BigDecimal.ONE).mesesCobertos(1).dataPagamento(LocalDateTime.now()).build();
+        when(pagamentoRepository.findById(1L)).thenReturn(Optional.of(pagamento));
+        when(pagamentoRepository.save(any(Pagamento.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PagamentoDTO dto = new PagamentoDTO();
+        dto.setValorPago(BigDecimal.TEN);
+        dto.setMesesCobertos(2);
+        dto.setDataPagamento(LocalDateTime.now());
+
+        PagamentoDTO result = pagamentoService.atualizarPagamento(1L, dto);
+
+        verify(statusPagamentoMensalRepository, times(2)).save(any(StatusPagamentoMensal.class));
+        assertEquals(dto.getValorPago(), result.getValorPago());
+    }
+
+    @Test
+    void testConsultarPagamento() {
+        Pagamento pagamento = Pagamento.builder().id(1L).valorPago(BigDecimal.TEN).build();
+        when(pagamentoRepository.findById(1L)).thenReturn(Optional.of(pagamento));
+
+        PagamentoDTO dto = pagamentoService.consultarPagamento(1L);
+
+        assertEquals(pagamento.getId(), dto.getId());
+        assertEquals(pagamento.getValorPago(), dto.getValorPago());
+    }
+
+    @Test
+    void testListarPagamentos() {
+        Pagamento p = Pagamento.builder().id(1L).valorPago(BigDecimal.TEN).assinante(new Assinante()).build();
+        Page<Pagamento> page = new PageImpl<>(Collections.singletonList(p));
+        when(pagamentoRepository.findPagamentos("", PageRequest.of(0, 10))).thenReturn(page);
+
+        Page<PagamentoDTO> expected = page.map(pg -> modelMapper.map(pg, PagamentoDTO.class));
+        Page<PagamentoDTO> result = pagamentoService.listarPagamentos("", PageRequest.of(0, 10));
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testListarPagamentosAssinante() {
+        Assinante assinante = new Assinante();
+        assinante.setId(1L);
+        Pagamento pagamento = Pagamento.builder().id(1L).assinante(assinante).valorPago(BigDecimal.TEN).mesesCobertos(2).dataPagamento(LocalDateTime.now()).build();
+        Page<Pagamento> page = new PageImpl<>(Collections.singletonList(pagamento));
+
+        when(pagamentoRepository.findPagamentosAssinante(1L, PageRequest.of(0, 10))).thenReturn(page);
+        when(statusPagamentoMensalRepository.findMesesByAssinanteId(1L, 1L)).thenReturn(Arrays.asList(1, 2));
+
+        Page<PagamentoDTO> result = pagamentoService.listarPagamentosAssinante(1L, PageRequest.of(0, 10));
+
+        assertEquals(1, result.getContent().size());
+        assertEquals(2, result.getContent().get(0).getMeses().size());
+    }
+}

--- a/src/test/java/io/github/vulpes/applications/service/PlataformaServiceTest.java
+++ b/src/test/java/io/github/vulpes/applications/service/PlataformaServiceTest.java
@@ -1,0 +1,129 @@
+package io.github.vulpes.applications.service;
+
+import io.github.vulpes.applications.dto.PlataformaDTO;
+import io.github.vulpes.applications.service.impl.PlataformaServiceImpl;
+import io.github.vulpes.domain.enums.TipoServico;
+import io.github.vulpes.domain.models.Plataforma;
+import io.github.vulpes.infrastructure.jpa.PlataformaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class PlataformaServiceTest {
+
+    @Mock
+    private PlataformaRepository plataformaRepository;
+
+    @InjectMocks
+    private PlataformaServiceImpl plataformaService;
+
+    private final ModelMapper modelMapper = new ModelMapper();
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        plataformaService = new PlataformaServiceImpl(plataformaRepository);
+    }
+
+    @Test
+    void testListarPlataformas() {
+        Plataforma p1 = Plataforma.builder().id(1L).nome("Netflix").preco(BigDecimal.TEN).build();
+        Plataforma p2 = Plataforma.builder().id(2L).nome("Prime").preco(BigDecimal.ONE).build();
+        List<Plataforma> plataformas = Arrays.asList(p1, p2);
+        Page<Plataforma> page = new PageImpl<>(plataformas);
+
+        when(plataformaRepository.findPlataforma("", PageRequest.of(0, 10))).thenReturn(page);
+
+        Page<PlataformaDTO> expected = page.map(plataforma -> modelMapper.map(plataforma, PlataformaDTO.class));
+        Page<PlataformaDTO> result = plataformaService.listarPlataformas("", PageRequest.of(0, 10));
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testBuscarPlataforma() {
+        Plataforma plataforma = Plataforma.builder().id(1L).nome("Netflix").preco(BigDecimal.TEN).build();
+        when(plataformaRepository.findById(1L)).thenReturn(Optional.of(plataforma));
+
+        PlataformaDTO dto = plataformaService.buscarPlataforma(1L);
+        assertEquals(plataforma.getId(), dto.getId());
+        assertEquals(plataforma.getNome(), dto.getNome());
+    }
+
+    @Test
+    void testCadastrarPlataforma() {
+        PlataformaDTO dto = new PlataformaDTO();
+        dto.setNome("Netflix");
+        dto.setPreco(BigDecimal.TEN);
+        dto.setUrl("http://netflix.com");
+        dto.setTipoServico(TipoServico.STREAMING);
+        dto.setTotalVagas(2);
+
+        when(plataformaRepository.save(any(Plataforma.class))).thenAnswer(invocation -> {
+            Plataforma p = invocation.getArgument(0);
+            p.setId(1L);
+            return p;
+        });
+
+        PlataformaDTO result = plataformaService.cadastrarPlataforma(dto);
+
+        ArgumentCaptor<Plataforma> captor = ArgumentCaptor.forClass(Plataforma.class);
+        verify(plataformaRepository).save(captor.capture());
+        Plataforma saved = captor.getValue();
+
+        assertEquals(dto.getNome(), saved.getNome());
+        assertEquals(dto.getTotalVagas(), saved.getVagasDisponiveis());
+        assertEquals(dto.getId(), result.getId());
+        assertEquals(dto.getNome(), result.getNome());
+    }
+
+    @Test
+    void testAtualizarPlataforma() {
+        Plataforma existente = Plataforma.builder().id(1L).nome("Old").preco(BigDecimal.ONE).build();
+        when(plataformaRepository.findById(1L)).thenReturn(Optional.of(existente));
+        when(plataformaRepository.save(any(Plataforma.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PlataformaDTO dto = new PlataformaDTO();
+        dto.setNome("Novo");
+        dto.setPreco(BigDecimal.TEN);
+        dto.setUrl("http://teste.com");
+        dto.setTipoServico(TipoServico.STREAMING);
+        dto.setTotalVagas(3);
+
+        PlataformaDTO result = plataformaService.atualizarPlataforma(1L, dto);
+
+        ArgumentCaptor<Plataforma> captor = ArgumentCaptor.forClass(Plataforma.class);
+        verify(plataformaRepository).save(captor.capture());
+        Plataforma saved = captor.getValue();
+        assertEquals(dto.getNome(), saved.getNome());
+        assertEquals(dto.getPreco(), saved.getPreco());
+
+        assertEquals(dto.getNome(), result.getNome());
+    }
+
+    @Test
+    void testExcluirPlataforma() {
+        Plataforma plataforma = Plataforma.builder().id(1L).nome("Netflix").preco(BigDecimal.TEN).build();
+        when(plataformaRepository.findById(1L)).thenReturn(Optional.of(plataforma));
+
+        plataformaService.excluirPlataforma(1L);
+
+        verify(plataformaRepository).deletePlataforma(1L);
+    }
+}

--- a/src/test/java/io/github/vulpes/applications/service/UsuarioServiceTest.java
+++ b/src/test/java/io/github/vulpes/applications/service/UsuarioServiceTest.java
@@ -1,0 +1,141 @@
+package io.github.vulpes.applications.service;
+
+import io.github.vulpes.applications.dto.UsuarioDTO;
+import io.github.vulpes.applications.service.impl.UsuarioServiceImpl;
+import io.github.vulpes.domain.models.Perfil;
+import io.github.vulpes.domain.models.Usuario;
+import io.github.vulpes.infrastructure.jpa.PerfilRepository;
+import io.github.vulpes.infrastructure.jpa.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class UsuarioServiceTest {
+
+    @Mock
+    private UsuarioRepository usuarioRepository;
+    @Mock
+    private PerfilRepository perfilRepository;
+
+    @InjectMocks
+    private UsuarioServiceImpl usuarioService;
+
+    private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        usuarioService = new UsuarioServiceImpl(usuarioRepository, perfilRepository);
+    }
+
+    @Test
+    void testCadastrarUsuario() {
+        UsuarioDTO dto = new UsuarioDTO();
+        dto.setNome("John");
+        dto.setSobrenome("Doe");
+        dto.setEmail("john@doe.com");
+        dto.setSenha("123");
+        dto.setPerfisId(Collections.singletonList(1L));
+
+        Perfil perfil = new Perfil();
+        perfil.setId(1L);
+
+        when(perfilRepository.findAllById(dto.getPerfisId())).thenReturn(Collections.singletonList(perfil));
+        when(usuarioRepository.save(any(Usuario.class))).thenAnswer(invocation -> {
+            Usuario u = invocation.getArgument(0);
+            u.setId(1L);
+            return u;
+        });
+
+        UsuarioDTO result = usuarioService.cadastrarUsuario(dto);
+
+        ArgumentCaptor<Usuario> captor = ArgumentCaptor.forClass(Usuario.class);
+        verify(usuarioRepository).save(captor.capture());
+        Usuario saved = captor.getValue();
+
+        assertTrue(passwordEncoder.matches("123", saved.getSenha()));
+        assertEquals(dto.getNome(), result.getNome());
+    }
+
+    @Test
+    void testBuscarUsuarioPorId() {
+        Usuario usuario = Usuario.builder().id(1L).nome("John").sobrenome("Doe").email("john@doe.com").build();
+        when(usuarioRepository.findById(1L)).thenReturn(Optional.of(usuario));
+
+        UsuarioDTO dto = usuarioService.buscarUsuarioPorId(1L);
+        assertEquals(usuario.getNome(), dto.getNome());
+    }
+
+    @Test
+    void testAtualizarUsuario() {
+        Usuario usuario = Usuario.builder().id(1L).nome("John").sobrenome("Doe").email("old@doe.com").build();
+        when(usuarioRepository.findById(1L)).thenReturn(Optional.of(usuario));
+        when(usuarioRepository.save(any(Usuario.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        UsuarioDTO dto = new UsuarioDTO();
+        dto.setNome("Novo");
+        dto.setSobrenome("Nome");
+        dto.setEmail("novo@teste.com");
+        dto.setPerfisId(Collections.singletonList(1L));
+        dto.setSenha("123");
+
+        UsuarioDTO result = usuarioService.atualizarUsuario(1L, dto);
+
+        assertEquals(dto.getNome(), result.getNome());
+        verify(usuarioRepository).save(usuario);
+    }
+
+    @Test
+    void testAtualizarSenha() {
+        Usuario usuario = Usuario.builder().id(1L).senha("antiga").build();
+        when(usuarioRepository.findById(1L)).thenReturn(Optional.of(usuario));
+        when(usuarioRepository.save(any(Usuario.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        usuarioService.atualizarSenha(1L, "nova");
+
+        ArgumentCaptor<Usuario> captor = ArgumentCaptor.forClass(Usuario.class);
+        verify(usuarioRepository).save(captor.capture());
+        Usuario saved = captor.getValue();
+
+        assertTrue(passwordEncoder.matches("nova", saved.getSenha()));
+    }
+
+    @Test
+    void testAtualizarPerfis() {
+        Usuario usuario = new Usuario();
+        usuario.setId(1L);
+        Perfil perfil = new Perfil();
+        perfil.setId(1L);
+        when(usuarioRepository.findById(1L)).thenReturn(Optional.of(usuario));
+        when(perfilRepository.findAllById(Arrays.asList(1L))).thenReturn(Arrays.asList(perfil));
+
+        usuarioService.atualizarPerfis(1L, Arrays.asList(1L));
+
+        verify(usuarioRepository).save(usuario);
+        assertEquals(1, usuario.getPerfis().size());
+    }
+
+    @Test
+    void testExcluirUsuario() {
+        Usuario usuario = new Usuario();
+        usuario.setId(1L);
+        when(usuarioRepository.findById(1L)).thenReturn(Optional.of(usuario));
+
+        usuarioService.excluirUsuario(1L);
+
+        verify(usuarioRepository).deleteUsuario(1L);
+    }
+}


### PR DESCRIPTION
## Summary
- add Mockito-based tests for PlataformaServiceImpl
- add Mockito-based tests for PagamentoServiceImpl
- add Mockito-based tests for UsuarioServiceImpl

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68754fcc0400832eab4e9ca5391db339